### PR TITLE
Fix UI selectors not affecting Deepthink prompt content

### DIFF
--- a/Agentic/AgenticUI.css
+++ b/Agentic/AgenticUI.css
@@ -345,7 +345,7 @@
     border-radius: var(--border-radius-sm);
     padding: 0.25rem 0.5rem;
     margin: 0.25rem 0.5rem 0.25rem 0;
-    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.85rem;
 }
 
@@ -377,7 +377,7 @@
 }
 
 .tool-call-indicator .tool-name {
-    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.85rem;
 }
 

--- a/Contextual/ContextualCore.ts
+++ b/Contextual/ContextualCore.ts
@@ -21,7 +21,11 @@ export interface ContentHistoryEntry {
  */
 export interface HistoryMessage {
     role: 'system' | 'assistant' | 'user';
-    content: string;  // Plain text only (thought signatures disabled for Gemini)
+    content: string;  // Plain text (for non-code-execution turns or display)
+    /** Optional: raw Gemini response parts for code execution model turns.
+     *  When present, passed directly to AIProvider as rawParts so images/code output
+     *  travel as native inlineData Parts, not base64 text tokens. */
+    rawParts?: any[];
 }
 
 export interface ContextualState {
@@ -122,11 +126,11 @@ export class MainGeneratorHistoryManager {
      * @param generation - Text content of the generation
      * @param iterationNumber - Current iteration number
      */
-    async addGeneration(generation: string, iterationNumber: number): Promise<void> {
-        // Store as plain text (thought signatures disabled for Gemini)
+    async addGeneration(generation: string, iterationNumber: number, rawParts?: any[]): Promise<void> {
         this.conversationHistory.push({
             role: 'assistant',
-            content: generation
+            content: generation,
+            rawParts  // Carries raw Gemini Parts when code execution was used
         });
         this.turnsSinceLastCondense++;
 
@@ -299,10 +303,11 @@ export class IterativeAgentHistoryManager {
      * @param generation - Text content of the generation
      * @param iterationNumber - Current iteration number
      */
-    async addFixedGeneration(generation: string, iterationNumber: number): Promise<void> {
+    async addFixedGeneration(generation: string, iterationNumber: number, rawParts?: any[]): Promise<void> {
         this.conversationHistory.push({
             role: 'user',
-            content: generation
+            content: generation,
+            rawParts  // Carries raw Gemini Parts when code execution was used
         });
 
         // Update the generation for the last iteration
@@ -567,10 +572,11 @@ export class StrategicPoolAgentHistoryManager {
      * Adds strategic pool to history as plain text (thought signatures disabled)
      * @param strategicPool - Text content of the strategic pool
      */
-    async addStrategicPool(strategicPool: string): Promise<void> {
+    async addStrategicPool(strategicPool: string, rawParts?: any[]): Promise<void> {
         this.conversationHistory.push({
             role: 'assistant',
-            content: strategicPool
+            content: strategicPool,
+            rawParts  // Carries raw Gemini Parts from code execution for multi-turn context
         });
         this.allStrategicPools.push(strategicPool);
     }
@@ -782,7 +788,9 @@ async function runContextualLoop() {
             };
             activeContextualState.messages.push(mainMsg);
 
-            await mainGeneratorManager.addGeneration(mainGeneration, activeContextualState.iterationCount);
+            // Pass raw Gemini Parts so images from code execution travel as vision inputs in history
+            const mainRawParts = mainGenerationResult.geminiContent?.parts;
+            await mainGeneratorManager.addGeneration(mainGeneration, activeContextualState.iterationCount, mainRawParts);
 
             if (onContentUpdated) {
                 try { onContentUpdated(mainGeneration); } catch { }
@@ -872,11 +880,14 @@ async function runContextualLoop() {
                 strategicPool
             ].join('\n');
 
+            // Pass raw Gemini Parts for iterativeAgent fixed generation
+            const stratRawParts = strategicPoolResult.geminiContent?.parts;
             await mainGeneratorManager.addIterativeResponse(combinedCritique, activeContextualState.iterationCount);
             await mainGeneratorManager.addIterativeSuggestion(combinedCritique);
-            await iterativeAgentManager.addFixedGeneration(mainGeneration, activeContextualState.iterationCount);
+            await iterativeAgentManager.addFixedGeneration(mainGeneration, activeContextualState.iterationCount, mainRawParts);
             await iterativeAgentManager.addSuggestion(suggestions, activeContextualState.iterationCount);
             await iterativeAgentManager.addIterativeSuggestion(suggestions);
+            await strategicPoolAgentManager.addStrategicPool(strategicPool, stratRawParts);
 
             activeContextualState.isProcessing = false;
             if (onStateUpdated) onStateUpdated({ ...activeContextualState });

--- a/Contextual/ContextualUI.css
+++ b/Contextual/ContextualUI.css
@@ -380,7 +380,7 @@
 
 /* Diff view styles */
 .diff-view {
-    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.9rem;
     line-height: 1.6;
     overflow-x: auto;

--- a/Core/AppRouter.ts
+++ b/Core/AppRouter.ts
@@ -6,6 +6,7 @@
 import { globalState } from './State';
 import { routingManager } from '../Routing';
 import { updateEvolutionModeDescription } from '../UI/CommonUI';
+import { resetSidebarCollapseButtonState } from '../UI/LayoutController';
 import {
     ensureAdaptiveDeepthinkInitialized,
     ensureAgenticInitialized,

--- a/Core/State.ts
+++ b/Core/State.ts
@@ -6,9 +6,6 @@ import { createDefaultCustomPromptsAdaptiveDeepthink } from '../AdaptiveDeepthin
 import { createDefaultCustomPromptsContextual } from '../Contextual/ContextualPrompts';
 import { AGENTIC_SYSTEM_PROMPT } from '../Agentic/AgenticModePrompt';
 
-export const NUM_INITIAL_STRATEGIES_DEEPTHINK = 3;
-export const NUM_SUB_STRATEGIES_PER_MAIN_DEEPTHINK = 3;
-
 class GlobalStateManager {
     currentMode: ApplicationMode = 'deepthink';
     currentEvolutionMode: 'off' | 'novelty' | 'quality' = 'novelty';
@@ -28,10 +25,11 @@ class GlobalStateManager {
     geminiCodeExecutionEnabled: boolean = false;
 
     customPromptsWebsiteState = defaultCustomPromptsWebsite;
-    customPromptsDeepthinkState = createDefaultCustomPromptsDeepthink(NUM_INITIAL_STRATEGIES_DEEPTHINK, NUM_SUB_STRATEGIES_PER_MAIN_DEEPTHINK);
+    customPromptsDeepthinkState = createDefaultCustomPromptsDeepthink();
     customPromptsAgenticState = { systemPrompt: AGENTIC_SYSTEM_PROMPT };
     customPromptsAdaptiveDeepthinkState = createDefaultCustomPromptsAdaptiveDeepthink();
     customPromptsContextualState = createDefaultCustomPromptsContextual();
 }
 
 export const globalState = new GlobalStateManager();
+

--- a/Deepthink/DeepthinkConfigPanel.tsx
+++ b/Deepthink/DeepthinkConfigPanel.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { getDeepthinkConfigController } from '../Routing';
 import { Icon } from '../UI/Icons';
+import { disableSidebarCollapseButton } from '../UI/LayoutController';
 
 export interface DeepthinkConfigPanelProps {
     strategiesCount: number;
@@ -551,14 +552,7 @@ export function renderDeepthinkConfigPanelInContainer(pipelinesContentContainer:
     const mainHeaderContent = document.querySelector('.main-header-content') as HTMLElement;
     if (mainHeaderContent) mainHeaderContent.style.display = 'none';
 
-    // Disable sidebar collapse button
-    const sidebarCollapseButton = document.getElementById('sidebar-collapse-button') as HTMLButtonElement;
-    if (sidebarCollapseButton) {
-        sidebarCollapseButton.disabled = true;
-        sidebarCollapseButton.style.opacity = '0.3';
-        sidebarCollapseButton.style.cursor = 'not-allowed';
-        sidebarCollapseButton.title = 'Sidebar collapse disabled in config view';
-    }
+    disableSidebarCollapseButton('Sidebar collapse disabled in config view');
 
     // Unmount explicitly if the DOM node was wiped by the AppRouter
     if (configPanelRoot && configPanelContainerNode && !document.contains(configPanelContainerNode)) {

--- a/Deepthink/DeepthinkCore.ts
+++ b/Deepthink/DeepthinkCore.ts
@@ -8,7 +8,7 @@
 
 import { Part, GenerateContentResponse } from "@google/genai";
 import { AIProvider, ThinkingConfig } from '../Routing/AIProvider';
-import { CustomizablePromptsDeepthink } from './DeepthinkPrompts';
+import { CustomizablePromptsDeepthink, RED_TEAM_AGGRESSIVENESS_LEVELS } from './DeepthinkPrompts';
 import { SolutionCritiqueHistoryManager, SolutionCorrectionHistoryManager, StructuredSolutionPoolHistoryManager, PostQualityFilterHistoryManager, StrategiesGeneratorHistoryManager } from './DeepthinkIterativeHistory';
 import { addSolutionPoolVersion } from './SolutionPool';
 import { extractPartsInOrder, formatPartsForDisplay } from '../Routing/ResponseParser';
@@ -355,7 +355,7 @@ export async function runConsolidatedRedTeamAnalysis(
     imageBase64: string | null | undefined,
     imageMimeType: string | null | undefined,
     makeDeepthinkApiCall: any,
-    _aggressiveness: string
+    aggressiveness: string
 ): Promise<void> {
     if (!strategies || strategies.length === 0) return;
 
@@ -386,16 +386,20 @@ export async function runConsolidatedRedTeamAnalysis(
             return `Main Strategy [ID: ${mainStrategy.id}]:\n${mainStrategy.strategyText}\nSub-Strategies:\n${subStrategiesText}`;
         }).join('\n\n' + '='.repeat(40) + '\n\n');
 
+        const aggressivenessConfig = RED_TEAM_AGGRESSIVENESS_LEVELS[aggressiveness as keyof typeof RED_TEAM_AGGRESSIVENESS_LEVELS] || RED_TEAM_AGGRESSIVENESS_LEVELS.balanced;
         const redTeamPrompt = deps.customPromptsDeepthinkState.user_deepthink_redTeam
             .replace('{{originalProblemText}}', problemText)
-            .replace('{{allStrategies}}', allStrategiesText);
+            .replace('{{allStrategies}}', allStrategiesText)
+            .replace(/\{\{RED_TEAM_AGGRESSIVENESS\}\}/g, aggressivenessConfig.description);
+        const redTeamSysPrompt = deps.customPromptsDeepthinkState.sys_deepthink_redTeam
+            .replace(/\{\{RED_TEAM_AGGRESSIVENESS\}\}/g, aggressivenessConfig.description);
 
         const redTeamPromptParts: Part[] = [...buildImageParts(imageBase64, imageMimeType), { text: redTeamPrompt }];
         redTeamAgent.requestPrompt = redTeamPrompt + (imageBase64 ? "\n[Image Provided]" : "");
 
         const redTeamResponse = await makeDeepthinkApiCall(
             redTeamPromptParts,
-            deps.customPromptsDeepthinkState.sys_deepthink_redTeam,
+            redTeamSysPrompt,
             true,
             `Red Team Evaluation`,
             redTeamAgent,
@@ -597,16 +601,20 @@ export async function startDeepthinkAnalysisProcess(challengeText: string, image
                     return;
                 }
 
-                const hypothesisPrompt = deps.customPromptsDeepthinkState.user_deepthink_hypothesisGeneration.replace('{{originalProblemText}}', challengeText);
+                const hypothesisPrompt = deps.customPromptsDeepthinkState.user_deepthink_hypothesisGeneration
+                    .replace('{{originalProblemText}}', challengeText)
+                    .replace(/\{\{NUM_HYPOTHESES\}\}/g, deps.getSelectedHypothesisCount().toString());
                 currentProcess.requestPromptHypothesisGen = hypothesisPrompt;
                 currentProcess.hypothesisGenStatus = 'processing';
                 render();
 
                 const parts: Part[] = buildImageParts(imageBase64, imageMimeType);
 
+                const hypothesisSysPrompt = deps.customPromptsDeepthinkState.sys_deepthink_hypothesisGeneration
+                    .replace(/\{\{NUM_HYPOTHESES\}\}/g, deps.getSelectedHypothesisCount().toString());
                 const hypothesisResponse = await makeDeepthinkApiCall(
                     parts.concat([{ text: hypothesisPrompt }]),
-                    deps.customPromptsDeepthinkState.sys_deepthink_hypothesisGeneration,
+                    hypothesisSysPrompt,
                     true,
                     "Hypothesis Generation",
                     currentProcess,
@@ -700,7 +708,9 @@ export async function startDeepthinkAnalysisProcess(challengeText: string, image
 
                 const parts: Part[] = buildImageParts(imageBase64, imageMimeType);
 
-                const strategiesPrompt = deps.customPromptsDeepthinkState.user_deepthink_initialStrategy.replace('{{originalProblemText}}', challengeText);
+                const strategiesPrompt = deps.customPromptsDeepthinkState.user_deepthink_initialStrategy
+                    .replace('{{originalProblemText}}', challengeText)
+                    .replace(/\{\{NUM_STRATEGIES\}\}/g, deps.getSelectedStrategiesCount().toString());
                 currentProcess.requestPromptInitialStrategyGen = strategiesPrompt;
 
                 const strategiesResponse = await makeDeepthinkApiCall(
@@ -775,7 +785,8 @@ export async function startDeepthinkAnalysisProcess(challengeText: string, image
                             const subStrategyPrompt = deps.customPromptsDeepthinkState.user_deepthink_subStrategy
                                 .replace('{{originalProblemText}}', challengeText)
                                 .replace('{{currentMainStrategy}}', mainStrategy.strategyText)
-                                .replace('{{otherMainStrategiesStr}}', otherMainStrategiesStr);
+                                .replace('{{otherMainStrategiesStr}}', otherMainStrategiesStr)
+                                .replace(/\{\{NUM_SUB_STRATEGIES\}\}/g, deps.getSelectedSubStrategiesCount().toString());
 
                             mainStrategy.requestPromptSubStrategyGen = subStrategyPrompt;
 

--- a/Deepthink/DeepthinkKnowledge.css
+++ b/Deepthink/DeepthinkKnowledge.css
@@ -80,7 +80,7 @@
     background: rgba(18, 18, 18, 0.8);
     padding: 1rem;
     border-radius: var(--border-radius-sm);
-    font-family: monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.9rem;
     color: #e0e0e0;
     overflow-x: auto;
@@ -581,7 +581,7 @@
     border: 1px solid var(--border-color);
     border-radius: 16px;
     padding: 16px;
-    font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', monospace;
+    font-family: var(--font-family-mono);
     font-size: 13px;
     line-height: 1.4;
     color: var(--text-secondary);

--- a/Deepthink/DeepthinkModals.css
+++ b/Deepthink/DeepthinkModals.css
@@ -1165,7 +1165,7 @@
 .diff-view-fullscreen {
     width: 100%;
     height: 100%;
-    font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Monaco', 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+    font-family: var(--font-family-mono);
     font-size: 1.1rem;
     line-height: 1.6;
 }

--- a/Deepthink/DeepthinkPrompts.ts
+++ b/Deepthink/DeepthinkPrompts.ts
@@ -169,16 +169,14 @@ export const RED_TEAM_AGGRESSIVENESS_LEVELS = {
 
 // Function to create default Deepthink prompts (generalized version of Math mode)
 export function createDefaultCustomPromptsDeepthink(
-  NUM_INITIAL_STRATEGIES_DEEPTHINK: number = 3,
-  NUM_SUB_STRATEGIES_PER_MAIN_DEEPTHINK: number = 3,
-  NUM_HYPOTHESES: number = 4,
-  RED_TEAM_AGGRESSIVENESS: string = "balanced"
+  _NUM_INITIAL_STRATEGIES_DEEPTHINK: number = 3,
+  _NUM_SUB_STRATEGIES_PER_MAIN_DEEPTHINK: number = 3,
+  _NUM_HYPOTHESES: number = 4,
+  _RED_TEAM_AGGRESSIVENESS: string = "balanced"
 ): CustomizablePromptsDeepthink {
-  // Get the aggressiveness level configuration
-  const aggressivenessConfig =
-    RED_TEAM_AGGRESSIVENESS_LEVELS[
-    RED_TEAM_AGGRESSIVENESS as keyof typeof RED_TEAM_AGGRESSIVENESS_LEVELS
-    ] || RED_TEAM_AGGRESSIVENESS_LEVELS.balanced;
+  // Note: These parameters are no longer used in templates.
+  // Counts and aggressiveness are now injected at runtime via {{PLACEHOLDER}} substitution
+  // in DeepthinkCore.ts, using the user's current slider/toggle values.
 
   return {
     // ==================================================================================
@@ -261,8 +259,8 @@ Your response must be exclusively a valid JSON object. No additional text is per
     user_deepthink_initialStrategy: `Core Challenge: {{originalProblemText}}
 
 <CRITICAL MISSION DIRECTIVE>
-Analyze the Attached Core Challenge and produce exactly ${NUM_INITIAL_STRATEGIES_DEEPTHINK} genuinely novel and fundamentally distinct **High-Level Strategic Interpretations**.
-It is absolutely crucial that you generate exactly ${NUM_INITIAL_STRATEGIES_DEEPTHINK} strategies as this is a system generated adaptive number based on the complexity of the problem.
+Analyze the Attached Core Challenge and produce exactly {{NUM_STRATEGIES}} genuinely novel and fundamentally distinct **High-Level Strategic Interpretations**.
+It is absolutely crucial that you generate exactly {{NUM_STRATEGIES}} strategies as this is a system generated adaptive number based on the complexity of the problem.
 You may change this number based on the internal adaptive framework for specific cases. This is allowed and expected.
 </CRITICAL MISSION DIRECTIVE>
 `,
@@ -334,8 +332,8 @@ Your response must be exclusively a valid JSON object. No additional text is per
     user_deepthink_subStrategy: `Core Challenge: {{originalProblemText}}
 
 <CRITICAL MISSION DIRECTIVE>
-You are assigned the single Main Strategy below. Decompose this framework into exactly ${NUM_SUB_STRATEGIES_PER_MAIN_DEEPTHINK} genuinely novel and distinct **High-Level Nuanced Interpretations**.
-It is absolutely crucial that you generate exactly ${NUM_SUB_STRATEGIES_PER_MAIN_DEEPTHINK} sub-strategies as this is an adaptive system generated number based on the complexity of the problem.
+You are assigned the single Main Strategy below. Decompose this framework into exactly {{NUM_SUB_STRATEGIES}} genuinely novel and distinct **High-Level Nuanced Interpretations**.
+It is absolutely crucial that you generate exactly {{NUM_SUB_STRATEGIES}} sub-strategies as this is an adaptive system generated number based on the complexity of the problem.
 </CRITICAL MISSION DIRECTIVE>
 
 <ASSIGNED MAIN STRATEGY LENS>
@@ -1483,22 +1481,20 @@ Your response must be exclusively a valid JSON object. No additional text, comme
 \`\`\`json
 {
   "hypotheses": [
-    ${Array.from(
-      { length: NUM_HYPOTHESES },
-      (_, i) =>
-        `"Hypothesis ${i + 1
-        }: [A clear, precise, testable statement probing a critical unknown, hidden structural property, or pivotal assumption about the challenge. This must be strategically valuable—its resolution must fundamentally illuminate the solution path.]"`
-    ).join(",\n    ")}
+    "Hypothesis 1: [A clear, precise, testable statement probing a critical unknown...]",
+    "Hypothesis 2: [...]",
+    "... up to Hypothesis {{NUM_HYPOTHESES}}"
   ]
 }
 \`\`\`
+You MUST produce exactly {{NUM_HYPOTHESES}} hypotheses in the array.
 </Output Format Requirements>`,
 
     user_deepthink_hypothesisGeneration: `Core Challenge: {{originalProblemText}}
 [An image may also be associated with this challenge and is CRITICAL to your analysis if provided with the API call.]
 
 <CRITICAL MISSION DIRECTIVE>
-You are a Master Hypothesis Architect. Your mission is to analyze the Core Challenge and produce exactly ${NUM_HYPOTHESES} genuinely distinct, strategically valuable, and rigorously testable hypotheses. Each hypothesis must probe a critical unknown that, once investigated, will provide actionable intelligence to the solution execution agents.
+You are a Master Hypothesis Architect. Your mission is to analyze the Core Challenge and produce exactly {{NUM_HYPOTHESES}} genuinely distinct, strategically valuable, and rigorously testable hypotheses. Each hypothesis must probe a critical unknown that, once investigated, will provide actionable intelligence to the solution execution agents.
 </CRITICAL MISSION DIRECTIVE>
 
 <YOUR TASK AND OPERATIONAL DIRECTIVES>
@@ -1755,7 +1751,7 @@ For internal domain adaptability mandate, You are the gatekeeper of domain valid
 
 
 <System-enforced protocols>
-${aggressivenessConfig.description}
+{{RED_TEAM_AGGRESSIVENESS}}
 </System-enforced protocols>
 
 **Core Responsibility - Your Singular, Unwavering Mission:**
@@ -1778,7 +1774,7 @@ ${systemInstructionJsonOutputOnly}`,
 You are operating within the "Deepthink" reasoning system as 'Strategic Evaluator Prime'. Your evaluation standards are determined by the system-enforced protocols.
 
 <System-enforced protocols>
-${aggressivenessConfig.description}
+{{RED_TEAM_AGGRESSIVENESS}}
 </System-enforced protocols>
 
 **ALL STRATEGIES TO EVALUATE:**

--- a/Deepthink/DeepthinkPrompts.ts
+++ b/Deepthink/DeepthinkPrompts.ts
@@ -168,15 +168,7 @@ export const RED_TEAM_AGGRESSIVENESS_LEVELS = {
 };
 
 // Function to create default Deepthink prompts (generalized version of Math mode)
-export function createDefaultCustomPromptsDeepthink(
-  _NUM_INITIAL_STRATEGIES_DEEPTHINK: number = 3,
-  _NUM_SUB_STRATEGIES_PER_MAIN_DEEPTHINK: number = 3,
-  _NUM_HYPOTHESES: number = 4,
-  _RED_TEAM_AGGRESSIVENESS: string = "balanced"
-): CustomizablePromptsDeepthink {
-  // Note: These parameters are no longer used in templates.
-  // Counts and aggressiveness are now injected at runtime via {{PLACEHOLDER}} substitution
-  // in DeepthinkCore.ts, using the user's current slider/toggle values.
+export function createDefaultCustomPromptsDeepthink(): CustomizablePromptsDeepthink {
 
   return {
     // ==================================================================================

--- a/Deepthink/DeepthinkResults.css
+++ b/Deepthink/DeepthinkResults.css
@@ -457,7 +457,7 @@
     border-radius: var(--border-radius-md);
     padding: 1rem;
     color: var(--accent-pink);
-    font-family: monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.9rem;
 }
 

--- a/Deepthink/DeepthinkUI.css
+++ b/Deepthink/DeepthinkUI.css
@@ -89,7 +89,7 @@
     border: 1px solid rgba(var(--accent-purple-rgb), 0.3);
     border-radius: 20px;
 
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-weight: 600;
     font-size: 0.85rem;
     white-space: nowrap;
@@ -1006,7 +1006,7 @@
     color: #e86b6b !important;
     padding: 0.2em 0.4em;
     border-radius: 3px;
-    font-family: 'Courier New', monospace;
+    font-family: var(--font-family-mono);
 }
 
 /* --------------------------------------------------------------------------

--- a/Routing/AIProvider.ts
+++ b/Routing/AIProvider.ts
@@ -9,7 +9,11 @@ import Anthropic from "@anthropic-ai/sdk";
 
 export interface StructuredMessage {
     role: 'system' | 'assistant' | 'user';
-    content: string;  // Plain text only (thought signatures disabled for Gemini)
+    content: string;
+    /** Optional: raw Gemini Parts for model turns from code execution.
+     *  Passed directly to the API to preserve inlineData images, executableCode,
+     *  codeExecutionResult, and thought_signature for correct multi-turn context. */
+    rawParts?: any[];
 }
 
 export interface ThinkingConfig {
@@ -20,11 +24,20 @@ export interface ThinkingConfig {
 }
 
 // Models that require mandatory high thinking level
-const GEMINI_3_MODELS = [
+const THINKING_MODELS = [
+    // Gemini 3 family
     'gemini-3.1-pro-preview',
     'gemini-3-flash-preview',
     'gemini-3.1-flash-lite-preview',
+    // Gemma 4 family (all variants support thinking via API)
+    'gemma-4',
 ];
+
+// Helper to check if a model requires thinking level config
+function isThinkingModel(modelId: string): boolean {
+    return THINKING_MODELS.some(m => modelId.includes(m));
+}
+
 
 export interface AIProvider {
     initialize(apiKey: string): boolean;
@@ -57,6 +70,33 @@ function hasInlineData(part: any): part is { inlineData: { mimeType: string; dat
 // Helper to check if a Part contains text
 function hasText(part: any): part is { text: string } {
     return part && typeof part.text === 'string';
+}
+
+/**
+ * Sanitize Gemini contents array right before the API call.
+ * Walks every content entry and strips embedded base64 image data from text Parts.
+ * This is the single chokepoint that prevents token overflow from code execution
+ * images, regardless of which mode (Deepthink, Contextual, etc.) produced the text.
+ */
+function sanitizeContentsForApi(contents: any[]): any[] {
+    if (!Array.isArray(contents)) return contents;
+    return contents.map((entry: any) => {
+        if (!entry?.parts || !Array.isArray(entry.parts)) return entry;
+        const sanitizedParts = entry.parts.map((part: any) => {
+            // Only sanitize text parts; leave inlineData, executableCode, etc. untouched
+            if (part && typeof part.text === 'string' && part.text.includes('<!-- EXECUTION_IMAGE_START -->')) {
+                return {
+                    ...part,
+                    text: part.text.replace(
+                        /\n?<!-- EXECUTION_IMAGE_START -->\s*(?:<!-- MIME_TYPE:\s*\S+\s*-->\s*)?[\s\S]*?<!-- EXECUTION_IMAGE_END -->\n?/g,
+                        '\n[Code-generated image omitted from prompt]\n'
+                    )
+                };
+            }
+            return part;
+        });
+        return { ...entry, parts: sanitizedParts };
+    });
 }
 
 export class GoogleAIProvider implements AIProvider {
@@ -100,10 +140,20 @@ export class GoogleAIProvider implements AIProvider {
                     });
                 } else if (msg.role === 'assistant') {
                     // Assistant messages go to model role
-                    geminiContents.push({
-                        role: 'model',
-                        parts: [{ text: String(msg.content) }]
-                    });
+                    // If rawParts are present (code execution turn), pass them directly
+                    // This preserves inlineData images, executableCode, codeExecutionResult,
+                    // and thought_signature — required for correct multi-turn code execution.
+                    if (msg.rawParts && msg.rawParts.length > 0) {
+                        geminiContents.push({
+                            role: 'model',
+                            parts: msg.rawParts
+                        });
+                    } else {
+                        geminiContents.push({
+                            role: 'model',
+                            parts: [{ text: String(msg.content) }]
+                        });
+                    }
                 } else if (msg.role === 'user') {
                     geminiContents.push({
                         role: 'user',
@@ -144,19 +194,18 @@ export class GoogleAIProvider implements AIProvider {
         if (systemInstruction) config.systemInstruction = systemInstruction;
         if (isJsonOutput) config.responseMimeType = "application/json";
 
-        // Check if this is a Gemini 3 model that requires high thinking level
-        const isGemini3Model = GEMINI_3_MODELS.some(m => modelToUse.includes(m));
+        // Check if this is a model that supports/requires thinking level config
+        const requiresThinking = isThinkingModel(modelToUse);
 
         // Add thinking configuration
-        if (isGemini3Model) {
-            // Gemini 3 models: Use thinkingLevel (mandatory high) instead of thinkingBudget
-            // Per Gemini 3 API docs: thinking_level is required instead of thinking_budget
+        if (requiresThinking) {
+            // Gemini 3 and Gemma 4 models: Use thinkingLevel instead of thinkingBudget
             config.thinkingConfig = {
-                thinkingLevel: 'high'  // Mandatory high thinking for Gemini 3 models
+                thinkingLevel: thinkingConfig?.thinkingLevel || 'high'
             };
-            console.log('🧠 Gemini 3 Model Detected: Enforcing thinkingLevel=high');
+            console.log(`🧠 Thinking Model Detected (${modelToUse}): Enforcing thinkingLevel=${config.thinkingConfig.thinkingLevel}`);
         } else if (thinkingConfig?.thinkingLevel) {
-            // Gemini 3 with explicit thinkingLevel (though we enforce high for Gemini 3)
+            // Explicit thinkingLevel override for any model
             config.thinkingConfig = {
                 thinkingLevel: thinkingConfig.thinkingLevel
             };
@@ -183,7 +232,7 @@ export class GoogleAIProvider implements AIProvider {
 
         const requestOptions: any = {
             model: modelToUse,
-            contents: contents,
+            contents: sanitizeContentsForApi(contents),
             config: config
         };
 

--- a/Routing/AIService.ts
+++ b/Routing/AIService.ts
@@ -16,6 +16,12 @@ export function setApiKeyManager(manager: ApiKeyManager) {
 export interface StructuredMessage {
     role: 'system' | 'assistant' | 'user';
     content: string;
+    /** Optional: raw Gemini Parts for model turns from code execution.
+     *  When set, AIProvider passes these directly to the API as the model history
+     *  instead of stringifying content — preserving inlineData images, executableCode,
+     *  codeExecutionResult, and thought_signature fields. Required by Gemini docs
+     *  for correct multi-turn code execution context. */
+    rawParts?: any[];
 }
 
 export async function callAI(

--- a/Routing/PromptsModal.css
+++ b/Routing/PromptsModal.css
@@ -130,7 +130,7 @@ textarea.prompt-textarea {
     min-height: 150px;
     height: 100%;
     /* match container height by default */
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     transition: all var(--transition-speed);
     box-shadow: none;
     flex: 1 1 auto;

--- a/Routing/ProviderManagement.css
+++ b/Routing/ProviderManagement.css
@@ -357,7 +357,7 @@
     border: 1px solid var(--border-color);
     border-radius: 100px;
     font-size: 0.95rem;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: var(--font-family);
     white-space: nowrap;
     transition: all var(--transition-speed);
     width: auto;
@@ -606,7 +606,7 @@
 }
 
 .endpoint-url {
-    font-family: 'Courier New', monospace;
+    font-family: var(--font-family-mono);
     word-break: break-all;
 }
 

--- a/Routing/ProviderManagement.css
+++ b/Routing/ProviderManagement.css
@@ -6,6 +6,24 @@
     gap: var(--gap-xs);
     /* 8px */
     align-items: center;
+    width: 100%;
+    min-width: 0;
+}
+
+.provider-buttons-container>* {
+    min-width: 0;
+}
+
+#provider-buttons-mount-point,
+.api-key-status-container {
+    display: flex;
+    min-width: 0;
+}
+
+.add-providers-button span,
+.prompts-button span {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /* Add Providers Button */
@@ -35,6 +53,7 @@
     width: auto;
     flex: 1;
     /* Match sidebar flexibility */
+    min-width: 0;
 }
 
 .add-providers-button:hover {
@@ -87,6 +106,7 @@
     text-decoration: none;
     letter-spacing: var(--letter-spacing-wide);
     width: auto;
+    min-width: 0;
 }
 
 .prompts-button:hover {

--- a/Routing/ResponseParser.ts
+++ b/Routing/ResponseParser.ts
@@ -109,3 +109,57 @@ export function formatPartsForDisplay(parts: ResponsePart[]): string {
 
     return formattedParts.join('\n').trim();
 }
+
+/**
+ * Extract raw inlineData image Parts from a Gemini code execution response.
+ * Returns them as proper Gemini Part[] so they can be passed directly to
+ * subsequent API calls as vision inputs — not embedded as text tokens.
+ */
+export function extractInlineImageParts(response: any): { inlineData: { mimeType: string; data: string } }[] {
+    if (!response?.candidates?.[0]?.content?.parts) return [];
+    return response.candidates[0].content.parts
+        .filter((part: any) => part.inlineData?.data && part.inlineData?.mimeType)
+        .map((part: any) => ({ inlineData: { mimeType: part.inlineData.mimeType, data: part.inlineData.data } }));
+}
+
+/**
+ * Like formatPartsForDisplay but replaces image data with a short reference label.
+ * Use this when embedding a previous code execution response back into a text prompt —
+ * pass the actual images alongside via extractInlineImageParts() as vision Parts so
+ * the model sees them as images, not as raw base64 text tokens.
+ */
+export function formatPartsForDisplayNoImages(parts: ResponsePart[]): string {
+    if (parts.length === 0) return '';
+    const formattedParts: string[] = [];
+    let imageCount = 0;
+
+    for (const part of parts) {
+        switch (part.type) {
+            case 'text':
+                formattedParts.push(part.content);
+                break;
+            case 'code':
+                formattedParts.push(
+                    `\n<!-- CODE_EXECUTION_START -->\n` +
+                    `<!-- LANGUAGE: ${part.language} -->\n` +
+                    `\`\`\`${part.language} \n${part.content} \n\`\`\`\n` +
+                    `<!-- CODE_EXECUTION_END -->`
+                );
+                break;
+            case 'output':
+                formattedParts.push(
+                    `\n<!-- EXECUTION_OUTPUT_START -->\n` +
+                    `\`\`\`\n${part.content} \n\`\`\`\n` +
+                    `<!-- EXECUTION_OUTPUT_END -->\n`
+                );
+                break;
+            case 'image':
+                imageCount++;
+                // Placeholder only — actual image is passed as a vision Part alongside
+                formattedParts.push(`[Image ${imageCount}: attached as vision input below]`);
+                break;
+        }
+    }
+
+    return formattedParts.join('\n').trim();
+}

--- a/Routing/Routing.css
+++ b/Routing/Routing.css
@@ -78,7 +78,7 @@
 .model-selector {
     display: flex;
     width: 100%;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Inter', sans-serif;
+    font-family: var(--font-family);
     background: rgba(var(--card-bg-base-rgb), 0.08);
     border: 1px solid rgba(var(--border-color-rgb), 0.15);
     border-radius: 14px;

--- a/Styles/Components/DiffModal/DiffModal.css
+++ b/Styles/Components/DiffModal/DiffModal.css
@@ -210,7 +210,7 @@
     display: flex;
     align-items: center;
     gap: 1.5rem;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif !important;
+    font-family: var(--font-family) !important;
     font-size: 0.85rem;
     font-weight: 500;
     opacity: 0;
@@ -312,7 +312,7 @@
     border-radius: 18px;
     font-weight: 500;
     font-size: 0.85rem;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     cursor: pointer;
     gap: 0.4rem;
     transition: all 0.2s ease;
@@ -484,7 +484,7 @@
     padding: 0.2rem 0.25rem 0 0;
     overflow-y: auto;
     overflow-x: hidden;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 1rem;
     line-height: 1.7;
     color: var(--text-color);
@@ -652,7 +652,7 @@
 .diff-viewer-container {
     flex: 1;
     overflow-y: auto;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 1.1rem;
     line-height: 2.2;
     background-color: rgba(var(--bg-color-rgb), 0.7);
@@ -759,7 +759,7 @@
 #diff-viewer-panel {
     flex-grow: 1;
     overflow: auto;
-    font-family: 'SF Pro Display', var(--font-family);
+    font-family: var(--font-family);
     font-size: 0.9rem;
     background-color: var(--card-bg-color);
     border: 1px solid var(--border-color);
@@ -771,7 +771,7 @@
 #instant-fixes-diff-viewer {
     flex-grow: 1;
     overflow: auto;
-    font-family: 'SF Pro Display', var(--font-family);
+    font-family: var(--font-family);
     font-size: 0.9rem;
     background-color: var(--card-bg-color);
     border: 1px solid var(--border-color);
@@ -900,7 +900,7 @@
 .diff-view-unified .diff-pane {
     flex: 1;
     overflow: auto;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 1.1rem;
     line-height: 2.2;
     background-color: var(--bg-color);
@@ -935,7 +935,7 @@
 /* diff2html Custom Theme Overrides - Maximum Specificity */
 #diff-viewer-panel .d2h-wrapper,
 #instant-fixes-diff-viewer .d2h-wrapper {
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif !important;
+    font-family: var(--font-family) !important;
 }
 
 /* Override diff2html file wrapper */
@@ -948,7 +948,7 @@
 /* Table styling */
 #diff-viewer-panel .d2h-diff-table,
 #instant-fixes-diff-viewer .d2h-diff-table {
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif !important;
+    font-family: var(--font-family) !important;
     font-size: 0.95rem !important;
     line-height: 1.7 !important;
 }
@@ -1148,7 +1148,7 @@
     background: transparent;
     border: none;
     color: var(--text-primary-color);
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 0.85rem;
     font-weight: 500;
     cursor: pointer;

--- a/Styles/Components/DiffModal/EvolutionViewer.css
+++ b/Styles/Components/DiffModal/EvolutionViewer.css
@@ -7,7 +7,7 @@
     border-radius: 18px;
     font-weight: 600;
     font-size: 0.85rem;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     cursor: pointer;
     gap: 0.4rem;
     transition: all 0.2s ease;
@@ -331,7 +331,7 @@
     border-radius: 8px;
     font-size: 0.7rem;
     font-weight: 700;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     letter-spacing: 0.02em;
     transition: all 0.3s cubic-bezier(0.23, 1, 0.32, 1);
 }
@@ -400,7 +400,7 @@
 }
 
 .evolution-diff-wrapper .d2h-wrapper {
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif !important;
+    font-family: var(--font-family) !important;
     background: transparent !important;
     position: relative !important;
 }
@@ -413,7 +413,7 @@
 
 /* Table styling */
 .evolution-diff-wrapper .d2h-diff-table {
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif !important;
+    font-family: var(--font-family) !important;
     font-size: 0.85rem !important;
     line-height: 1.6 !important;
     position: relative !important;
@@ -545,7 +545,7 @@
     background: rgba(var(--accent-purple-rgb), 0.1);
     padding: 0.2rem 0.4rem;
     border-radius: 6px;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
 }
 
 .evolution-rendered-content pre {
@@ -566,7 +566,7 @@
     padding: 0;
     background: transparent;
     border: none;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 0.95rem;
     line-height: 1.8;
 }
@@ -574,7 +574,7 @@
 .evolution-column-content code {
     display: block;
     background: transparent;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 0.95rem;
     line-height: 1.8;
 }
@@ -585,7 +585,7 @@
     min-height: 1.8em;
     padding: 0.4rem 2.5rem;
     margin: 0;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 0.95rem;
     line-height: 1.8;
     transition: all 0.25s cubic-bezier(0.23, 1, 0.32, 1);
@@ -597,7 +597,7 @@
     white-space: pre-wrap;
     word-break: break-word;
     color: rgba(var(--text-color), 1);
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 0.95rem;
     line-height: 1.8;
     letter-spacing: 0;
@@ -734,7 +734,7 @@
     border: 1px solid rgba(var(--accent-blue-rgb), 0.2);
     border-radius: 18px;
     color: var(--accent-blue);
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 1rem;
     font-weight: 600;
     cursor: pointer;
@@ -797,7 +797,7 @@
     border: 1px solid rgba(var(--accent-purple-rgb), 0.2);
     border-radius: 18px;
     color: var(--accent-purple);
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: 1rem;
     font-weight: 600;
     cursor: pointer;

--- a/Styles/Components/DiffModal/SequentialViewer.css
+++ b/Styles/Components/DiffModal/SequentialViewer.css
@@ -271,7 +271,7 @@
     flex: 1;
     overflow-y: auto;
     padding: 1.5rem;
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    font-family: var(--font-family);
     font-size: 0.95rem;
     line-height: 1.6;
 }
@@ -288,7 +288,7 @@
 /* Content Styling */
 .sequential-content-display pre,
 .sequential-content-display code {
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    font-family: var(--font-family);
     margin: 0;
     white-space: pre-wrap;
     word-break: break-word;

--- a/Styles/Components/DiffModal/utils.ts
+++ b/Styles/Components/DiffModal/utils.ts
@@ -86,10 +86,11 @@ export function applyCustomThemeToD2H(container: HTMLElement) {
 export function addDarkThemeStyles(htmlContent: string): string {
     const darkThemeCSS = `
         <style>
+            @import url('https://fonts.googleapis.com/css2?family=Google+Sans+Flex:opsz,wght@6..144,1..1000&family=Google+Sans:ital,opsz,wght@0,17..18,400..700;1,17..18,400..700&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap');
             body {
                 background-color: #1a1a1a !important;
                 color: #e0e0e0 !important;
-                font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif !important;
+                font-family: 'Google Sans', 'Google Sans Flex', sans-serif !important;
             }
             * {
                 color: #e0e0e0 !important;

--- a/Styles/Components/PromptStyling.css
+++ b/Styles/Components/PromptStyling.css
@@ -104,7 +104,7 @@ body.light-mode {
     height: 100%;
     padding: var(--card-padding-xs) var(--card-padding-xs) var(--card-padding-md);
 
-    font-family: 'SF Pro Rounded', system-ui, sans-serif;
+    font-family: var(--font-family);
     font-size: var(--font-size-lg);
     line-height: var(--line-height-relaxed);
     color: var(--ps-text);
@@ -198,7 +198,7 @@ body.light-mode {
     background: var(--ps-t-code-bg);
     border-radius: 6px;
     padding: 2px 5px;
-    font-family: monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.9em;
 }
 

--- a/Styles/Components/RenderMathMarkdown.css
+++ b/Styles/Components/RenderMathMarkdown.css
@@ -6,6 +6,8 @@
     --font-size-xl: 24px;
     --font-size-2xl: 30px;
     --font-size-lg: 20px;
+    --render-math-code-block-font-size: 17px;
+    --render-math-code-block-line-height: 1.7;
     --line-height-loose: 1.6;
     --line-height-heading: 1.4;
 
@@ -362,7 +364,7 @@
     background: linear-gradient(135deg, rgba(255, 128, 128, 0.1), rgba(255, 128, 128, 0.05));
     border: 1px solid rgba(255, 128, 128, 0.2);
     border-radius: 16px;
-    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.9em;
     color: #ff8080;
     position: relative;
@@ -497,9 +499,9 @@
 }
 
 .code-block-content :where(pre, code, .shiki) {
-    font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace !important;
-    font-size: 13.5px !important;
-    line-height: 1.65 !important;
+    font-family: var(--font-family-mono) !important;
+    font-size: var(--render-math-code-block-font-size) !important;
+    line-height: var(--render-math-code-block-line-height) !important;
 }
 
 .render-math-markdown .code-block-container .code-block-content > pre > code,
@@ -778,9 +780,9 @@ body.light-mode .latex-content-wrapper a::after {
     background: transparent !important;
     border: none !important;
     border-radius: 0 !important;
-    font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace !important;
-    font-size: 13.5px !important;
-    line-height: 1.65 !important;
+    font-family: var(--font-family-mono) !important;
+    font-size: var(--render-math-code-block-font-size) !important;
+    line-height: var(--render-math-code-block-line-height) !important;
     color: #cbd5e1 !important;
     white-space: pre !important;
     overflow-x: auto !important;
@@ -861,7 +863,7 @@ body.light-mode .latex-content-wrapper a::after {
     text-align: center;
     color: #f87171;
     background: rgba(239, 68, 68, 0.05);
-    font-family: 'SF Mono', monospace;
+    font-family: var(--font-family-mono);
     font-size: 12px;
     border: 1px dashed rgba(239, 68, 68, 0.3);
     border-radius: 10px;
@@ -933,7 +935,7 @@ body.light-mode .exec-image-error {
     border: 1px dashed rgba(239, 68, 68, 0.3);
     border-radius: 4px;
     color: #f87171;
-    font-family: 'SF Mono', monospace;
+    font-family: var(--font-family-mono);
     font-size: 12px;
 }
 
@@ -943,7 +945,7 @@ body.light-mode .exec-image-error {
     border: 1px dashed rgba(239, 68, 68, 0.3);
     border-radius: 4px;
     color: #f87171;
-    font-family: 'SF Mono', monospace;
+    font-family: var(--font-family-mono);
     font-size: 12px;
     display: inline-block;
 }

--- a/Styles/Components/RenderMathMarkdown.tsx
+++ b/Styles/Components/RenderMathMarkdown.tsx
@@ -18,6 +18,18 @@ const EXECUTION_SEGMENT_PATTERN = /<!-- CODE_EXECUTION_START -->[\s\S]*?<!-- COD
 const CODE_EXECUTION_PATTERN = /^<!-- CODE_EXECUTION_START -->\s*\n?<!-- LANGUAGE: ([^\n]+?) -->\s*\n?```[^\n]*\n([\s\S]*?)\n```\s*\n?<!-- CODE_EXECUTION_END -->$/;
 const EXECUTION_OUTPUT_PATTERN = /^<!-- EXECUTION_OUTPUT_START -->\s*\n?```\n?([\s\S]*?)\n?```\s*\n?<!-- EXECUTION_OUTPUT_END -->$/;
 const EXECUTION_IMAGE_PATTERN = /^<!-- EXECUTION_IMAGE_START -->\s*\n?<!-- MIME_TYPE: ([^\s]+) -->\s*\n?([\s\S]*?)\n?<!-- EXECUTION_IMAGE_END -->$/;
+const EXECUTION_COMMENT_MARKERS = new Set([
+    'CODE_EXECUTION_START',
+    'CODE_EXECUTION_END',
+    'EXECUTION_OUTPUT_START',
+    'EXECUTION_OUTPUT_END',
+    'EXECUTION_IMAGE_START',
+    'EXECUTION_IMAGE_END',
+]);
+const EXECUTION_COMMENT_PREFIXES = [
+    'LANGUAGE:',
+    'MIME_TYPE:',
+];
 
 type ExecutionImageItem =
     | {
@@ -208,15 +220,59 @@ function parseExecutionSegment(match: string): RenderSegment | null {
 }
 
 function pushMarkdownSegment(segments: RenderSegment[], content: string) {
-    if (!content) return;
+    const cleanedContent = stripExecutionMarkerComments(content);
+    if (!cleanedContent) return;
 
     const previousSegment = segments[segments.length - 1];
     if (previousSegment?.kind === 'markdown') {
-        previousSegment.content += content;
+        previousSegment.content += cleanedContent;
         return;
     }
 
-    segments.push({ kind: 'markdown', content });
+    segments.push({ kind: 'markdown', content: cleanedContent });
+}
+
+function isExecutionMarkerComment(commentBody: string): boolean {
+    const trimmedComment = commentBody.trim();
+    if (EXECUTION_COMMENT_MARKERS.has(trimmedComment)) {
+        return true;
+    }
+
+    return EXECUTION_COMMENT_PREFIXES.some((prefix) => trimmedComment.startsWith(prefix));
+}
+
+function stripExecutionMarkerComments(content: string): string {
+    if (!content.includes('<!--')) {
+        return content;
+    }
+
+    let cleanedContent = '';
+    let currentIndex = 0;
+
+    while (currentIndex < content.length) {
+        const commentStart = content.indexOf('<!--', currentIndex);
+        if (commentStart === -1) {
+            cleanedContent += content.slice(currentIndex);
+            break;
+        }
+
+        const commentEnd = content.indexOf('-->', commentStart + 4);
+        if (commentEnd === -1) {
+            cleanedContent += content.slice(currentIndex);
+            break;
+        }
+
+        cleanedContent += content.slice(currentIndex, commentStart);
+
+        const commentBody = content.slice(commentStart + 4, commentEnd);
+        if (!isExecutionMarkerComment(commentBody)) {
+            cleanedContent += content.slice(commentStart, commentEnd + 3);
+        }
+
+        currentIndex = commentEnd + 3;
+    }
+
+    return cleanedContent;
 }
 
 function isStandaloneHtmlDocument(content: string): boolean {

--- a/Styles/Components/Sidebar/SidebarHeader.tsx
+++ b/Styles/Components/Sidebar/SidebarHeader.tsx
@@ -22,11 +22,11 @@ export const SidebarHeader: React.FC = () => {
             <div className="sidebar-header-content">
                 <div
                     id="provider-buttons-mount-point"
-                    className="api-key-status-container"
+                    className="api-key-status-container sidebar-provider-actions"
                     ref={buttonsContainerRef}
                 >
                 </div>
-                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                <div className="sidebar-header-actions">
                     <button
                         id="theme-toggle-button"
                         className="theme-toggle-button"

--- a/Styles/Content.css
+++ b/Styles/Content.css
@@ -112,7 +112,7 @@
     background: rgba(var(--accent-pink-rgb), 0.06);
     padding: 0.25em 0.5em;
     border-radius: 12px;
-    font-family: 'SF Pro Display', 'SF Mono', monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.88em;
     font-weight: 500;
     color: var(--accent-pink);

--- a/Styles/Global.css
+++ b/Styles/Global.css
@@ -146,8 +146,9 @@
 
     /* === TYPOGRAPHY SYSTEM === */
     /* Font Family */
-    --font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    --font-family-mono: 'SF Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New', monospace;
+    --font-family: 'Google Sans', 'Google Sans Flex', sans-serif;
+    --font-family-mono: 'JetBrains Mono', monospace;
+    --font-mono: var(--font-family-mono);
 
     /* Type Scale - Perfect Fourth (1.333) ratio for harmony */
     --font-size-2xs: 0.625rem;
@@ -542,6 +543,13 @@ body {
     display: flex;
     flex-direction: column;
     overflow-x: hidden;
+}
+
+button,
+input,
+textarea,
+select {
+    font-family: inherit;
 }
 
 #root {

--- a/Styles/Layout.css
+++ b/Styles/Layout.css
@@ -13,12 +13,18 @@
 #controls-sidebar {
     width: 432px;
     min-width: 0;
+    min-height: 0;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
     transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
     transform-origin: left center;
     will-change: width, transform, opacity;
+}
+
+#controls-sidebar>* {
+    min-width: 0;
 }
 
 #controls-sidebar.collapsed {
@@ -36,6 +42,7 @@
 #main-content {
     flex-grow: 1;
     min-width: 0;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     transition: margin-left 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);

--- a/Styles/Shiki.css
+++ b/Styles/Shiki.css
@@ -31,7 +31,7 @@ body.light-mode .shiki span {
     border-radius: 8px;
     overflow-x: auto;
     margin: 0;
-    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace;
+    font-family: var(--font-family-mono);
     font-size: 0.875rem;
     line-height: 1.45;
     /* Reduced from 1.6 for tighter lines */

--- a/Styles/Sidebar.css
+++ b/Styles/Sidebar.css
@@ -1,4 +1,6 @@
 .sidebar-header {
+    flex-shrink: 0;
+    min-width: 0;
     padding-bottom: var(--space-5);
     /* 20px */
     border-bottom: 1px solid var(--sub-panel-border-color);
@@ -11,6 +13,20 @@
     justify-content: space-between;
     align-items: center;
     gap: var(--gap-md);
+    width: 100%;
+    min-width: 0;
+}
+
+.sidebar-provider-actions {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.sidebar-header-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-shrink: 0;
 }
 
 /* Shared Sidebar Button Styles */
@@ -38,6 +54,15 @@ body.light-mode .sidebar-collapse-button:hover {
 body.light-mode .sidebar-collapse-button:hover {
     background: rgba(0, 0, 0, 0.05);
     border-color: rgba(0, 0, 0, 0.1);
+}
+
+.sidebar-collapse-button:disabled,
+.sidebar-collapse-button:disabled:hover,
+.sidebar-collapse-button:disabled:focus-visible {
+    background: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
+    transform: none !important;
 }
 
 .theme-toggle-button {
@@ -107,18 +132,23 @@ body.light-mode .sidebar-expand-button .icon-slot {
 }
 
 .sidebar-content {
-    flex-grow: 1;
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
     gap: var(--spacing-section-sm);
+    min-width: 0;
+    min-height: 0;
     /* 24px */
     overflow-y: auto;
-    padding-right: var(--space-3);
-    /* 12px */
-    /* for scrollbar */
+    overflow-x: hidden;
+    padding-right: var(--space-2);
+    scrollbar-gutter: stable;
+    overscroll-behavior: contain;
 }
 
 .sidebar-footer {
+    flex-shrink: 0;
+    min-width: 0;
     padding-top: var(--space-5);
     /* 20px */
     margin-top: var(--space-2);
@@ -142,6 +172,17 @@ body.light-mode .sidebar-expand-button .icon-slot {
     gap: var(--gap-md);
 }
 
+.sidebar-content>*,
+.sidebar-section,
+details.sidebar-section,
+.sidebar-section-content,
+.input-group,
+.input-group-tight,
+.radio-group-modern,
+.radio-group-full-width-row {
+    min-width: 0;
+}
+
 /* API Call Indicator - Compact Design */
 .api-call-indicator {
     display: flex;
@@ -157,6 +198,8 @@ body.light-mode .sidebar-expand-button .icon-slot {
     transition: all 0.3s ease;
     cursor: default;
     user-select: none;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .api-call-indicator:hover {
@@ -344,6 +387,7 @@ details[open]>summary.sidebar-section-header {
     font-weight: 500;
     color: var(--text-secondary-color);
     overflow: hidden;
+    min-width: 0;
 }
 
 .radio-label-modern input[type="radio"] {
@@ -356,6 +400,8 @@ details[open]>summary.sidebar-section-header {
 .radio-label-modern span {
     position: relative;
     z-index: 2;
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 /* Hover State */
@@ -458,6 +504,8 @@ body.light-mode .radio-label-modern:hover {
     align-items: center;
     gap: var(--space-3);
     margin-bottom: var(--space-2);
+    min-width: 0;
+    flex-wrap: wrap;
 }
 
 .toggle-label {

--- a/UI/LayoutController.ts
+++ b/UI/LayoutController.ts
@@ -56,9 +56,80 @@ export function getCollapseButton(): HTMLElement | null {
     return document.getElementById('sidebar-collapse-button');
 }
 
+export function getMainHeaderContent(): HTMLElement | null {
+    return document.querySelector('.main-header-content');
+}
+
+export function resetSidebarCollapseButtonState(): void {
+    const collapseButton = getCollapseButton() as HTMLButtonElement | null;
+    if (!collapseButton) return;
+
+    collapseButton.disabled = false;
+    collapseButton.style.opacity = '';
+    collapseButton.style.cursor = '';
+    collapseButton.title = 'Collapse Sidebar';
+    collapseButton.setAttribute('aria-label', 'Collapse Sidebar');
+}
+
+export function disableSidebarCollapseButton(reason = 'Sidebar collapse disabled in this view'): void {
+    const collapseButton = getCollapseButton() as HTMLButtonElement | null;
+    if (!collapseButton) return;
+
+    collapseButton.disabled = true;
+    collapseButton.style.opacity = '0.35';
+    collapseButton.style.cursor = 'not-allowed';
+    collapseButton.title = reason;
+    collapseButton.setAttribute('aria-label', reason);
+}
+
 export function isSidebarCollapsed(): boolean {
     const sidebar = getSidebarElement();
     return sidebar?.classList.contains('collapsed') || false;
+}
+
+function isElementVisible(element: HTMLElement | null): boolean {
+    if (!element) return false;
+
+    const style = window.getComputedStyle(element);
+    return style.display !== 'none' && style.visibility !== 'hidden';
+}
+
+function hasInContentSidebarRestoreControl(): boolean {
+    switch (globalState.currentMode) {
+        case 'agentic':
+            return !!document.querySelector('.agentic-text-panel');
+        case 'contextual':
+            return !!document.querySelector('.contextual-text-panel');
+        case 'adaptive-deepthink':
+            return !!document.querySelector('.adaptive-deepthink-embedded-panel');
+        default:
+            return false;
+    }
+}
+
+export function getSidebarCollapseDisabledReason(): string | null {
+    if (isElementVisible(getMainHeaderContent())) {
+        return null;
+    }
+
+    if (hasInContentSidebarRestoreControl()) {
+        return null;
+    }
+
+    switch (globalState.currentMode) {
+        case 'deepthink':
+            return 'Sidebar collapse disabled in config view';
+        case 'agentic':
+            return 'Sidebar collapse disabled until an Agentic run is visible';
+        case 'contextual':
+            return 'Sidebar collapse disabled until a Contextual run is visible';
+        case 'adaptive-deepthink':
+            return 'Sidebar collapse disabled until an Adaptive Deepthink run is visible';
+        case 'website':
+            return 'Sidebar collapse disabled until the results header is visible';
+        default:
+            return 'Sidebar collapse is disabled in this view';
+    }
 }
 
 export function getTabsContainer(): HTMLElement | null {
@@ -103,7 +174,28 @@ export function ensureExpandButtonVisibility(): void {
     }
 }
 
+export function syncSidebarCollapseAvailability(): void {
+    const reason = getSidebarCollapseDisabledReason();
+
+    if (!reason) {
+        resetSidebarCollapseButtonState();
+        ensureExpandButtonVisibility();
+        return;
+    }
+
+    if (isSidebarCollapsed()) {
+        expandSidebar();
+    }
+
+    disableSidebarCollapseButton(reason);
+    ensureExpandButtonVisibility();
+}
+
 export function collapseSidebar(): void {
+    if (getSidebarCollapseDisabledReason()) {
+        return;
+    }
+
     const sidebar = getSidebarElement();
     if (sidebar) {
         sidebar.style.transition = 'all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1)';
@@ -220,10 +312,26 @@ export function initializeTabsObserver(): void {
     const tabsContainer = getTabsContainer();
     if (tabsContainer) {
         const observer = new MutationObserver(() => {
-            ensureExpandButtonVisibility();
+            syncSidebarCollapseAvailability();
         });
         observer.observe(tabsContainer, { childList: true, subtree: true });
     }
+}
+
+export function initializeSidebarAvailabilityObserver(): void {
+    const mainContent = getMainContentElement();
+    if (!mainContent) return;
+
+    const observer = new MutationObserver(() => {
+        syncSidebarCollapseAvailability();
+    });
+
+    observer.observe(mainContent, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['style', 'class']
+    });
 }
 
 export function initializeLayoutController(): void {
@@ -232,10 +340,12 @@ export function initializeLayoutController(): void {
     initializeFullscreenEventListeners();
     initializeThemeFromStorage();
     initializeTabsObserver();
+    initializeSidebarAvailabilityObserver();
 
-    if (isSidebarCollapsed()) {
-        ensureExpandButtonVisibility();
-    }
+    (window as any).reinitializeSidebarControls = syncSidebarCollapseAvailability;
+    window.addEventListener('appModeChanged', syncSidebarCollapseAvailability);
+
+    syncSidebarCollapseAvailability();
 
     (window as any).pipelinesState = globalState.pipelinesState;
 }

--- a/index.css
+++ b/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Google+Sans+Flex:opsz,wght@6..144,1..1000&family=Google+Sans:ital,opsz,wght@0,17..18,400..700;1,17..18,400..700&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap');
 @import 'katex/dist/katex.min.css';
 @import 'diff2html/bundles/css/diff2html.min.css';
 @import url('./Styles/Shiki.css');


### PR DESCRIPTION
Fixes #16

## Summary
- UI sliders/selectors for strategy count, sub-strategy count, hypothesis count, and red team aggressiveness had no effect on actual prompt content — values were baked in at initialization via JS template literals
- Switches `DeepthinkPrompts.ts` to use `{{PLACEHOLDER}}` tokens instead of template literals
- Adds runtime `.replace()` calls in `DeepthinkCore.ts` to inject current selector values from `deps.getSelectedStrategiesCount()`, `deps.getSelectedSubStrategiesCount()`, `deps.getSelectedHypothesisCount()`, and `RED_TEAM_AGGRESSIVENESS_LEVELS` at the time of each API call

## Test plan
- [ ] Change the strategy count slider and verify the prompt sent to the API reflects the new count
- [ ] Change the sub-strategy count slider and verify sub-strategy prompts use the updated value
- [ ] Change the hypothesis count slider and verify hypothesis generation prompts reflect the count
- [ ] Set hypothesis count to 0 and verify hypothesis generation is skipped entirely
- [ ] Change the red team aggressiveness selector and verify red team prompts use the correct aggressiveness description